### PR TITLE
fix: Properly set up CORS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const cors = require('cors')
 const express = require('express')
 const querystring = require('querystring')
 const parseAlgoliaSQL = require('./src/parseAlgoliaSQL')
@@ -17,13 +18,6 @@ const wrapAsyncMiddleware = asyncMiddleware => (req, res, next) => {
     })
 }
 
-const corsMiddleware = (req, res, next) => {
-  res.set({
-    'Access-Control-Allow-Origin': '*'
-  })
-  next()
-}
-
 const { v4 } = require('uuid')
 
 const createServer = (options) => {
@@ -37,7 +31,7 @@ const createServer = (options) => {
   const app = express()
 
   app.use(express.json({ type: '*/*', limit: '50mb' }))
-  app.use(corsMiddleware)
+  app.use(cors())
 
   // See docs at https://www.algolia.com/doc/api-reference/api-methods/get-related-products/
   // This endpoint mimics the recommendation engine of Algolia.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start:container": "node cli.js"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.16.4",
     "minimist": "^1.2.3",
     "search-index": "^1.0.1",


### PR DESCRIPTION
This fixes access to Algolite from a locally running Apify Console, fixing access to Store for example.